### PR TITLE
PAM variant annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,6 +603,8 @@ Comma-separated values (CSV) file containing name, label, and all metadata of th
 
 For cDNA targets, the reference chromosome (`ref_chr`) and strand (`ref_strand`) will be missing and all positions will be relative to the cDNA sequence. All fields related to PAM protection (`pam_seq`) and custom VCF variants (`vcf_alias` and `vcf_var_id`), features unavailable for this target type, will also be empty.
 
+Array fields use the semicolon as separator.
+
 |Field|Format|Description|
 |-|-|-|
 |`oligo_name`|string|Name of the oligonucleotide.|
@@ -629,8 +631,8 @@ For cDNA targets, the reference chromosome (`ref_chr`) and strand (`ref_strand`)
 |`mutator`|type of mutator|Label of the [type of mutator](#mutation-types) that generated the oligonucleotide.|
 |`oligo_length`|integer|Oligonucleotide length.|
 |`mseq`|DNA sequence|Full oligonucleotide sequence (with adaptors, if any).|
-|`pam_mut_annot`|`syn`\|`mis`\|`non`\|`ncd`|Applied PAM protection variant [mutation types](#mutation-types) (or `ncd` if affecting a noncoding region)|
-|`pam_mut_sgrna_id`|sgRNA ID|sgRNA ID bound to the PAM protection variant affecting the same codon as the mutation, if any (CDS only)|
+|`pam_mut_annot`|Array of `syn`\|`mis`\|`non`\|`ncd`|Applied PAM protection variant [mutation types](#mutation-types) (or `ncd` if affecting a noncoding region)|
+|`pam_mut_sgrna_id`|Array of sgRNA ID's|sgRNA ID's bound to the PAM protection variants affecting the same codons as the mutation, if any (CDS only)|
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -629,6 +629,8 @@ For cDNA targets, the reference chromosome (`ref_chr`) and strand (`ref_strand`)
 |`mutator`|type of mutator|Label of the [type of mutator](#mutation-types) that generated the oligonucleotide.|
 |`oligo_length`|integer|Oligonucleotide length.|
 |`mseq`|DNA sequence|Full oligonucleotide sequence (with adaptors, if any).|
+|`pam_mut_annot`|`syn`\|`mis`\|`non`\|`ncd`|Applied PAM protection variant [mutation types](#mutation-types) (or `ncd` if affecting a noncoding region)|
+|`pam_mut_sgrna_id`|sgRNA ID|sgRNA ID bound to the PAM protection variant affecting the same codon as the mutation, if any (CDS only)|
 
 Example:
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,7 +1,7 @@
 chardet==4.0.0
-click==7.1.2
-cython==0.29.22
-numpy==1.20.2
+click==8.1.3
+cython==0.29.30
+numpy==1.21.6
 pandas==1.1.5
-pyranges==0.0.95
-pysam==0.16.0.1
+pyranges==0.0.117
+pysam==0.19.1

--- a/src/valiant/cdna_cli.py
+++ b/src/valiant/cdna_cli.py
@@ -100,10 +100,9 @@ def get_annotated_cdna_mutations(
     sequence, cds_ext_5p, cds_ext_3p = cdna.get_extended_subsequence(
         targeton_cfg.r2_range)
     seq = sequence.sequence
-    return CDSTargeton(
-        seq, seq, StrandedPositionRange.to_plus_strand(
-            targeton_cfg.r2_range), cds_ext_5p, cds_ext_3p).compute_mutations(
-                targeton_cfg.mutators, aux)
+    spr = StrandedPositionRange.to_plus_strand(targeton_cfg.r2_range)
+    targeton = CDSTargeton.build_without_variants(spr, seq, cds_ext_5p, cds_ext_3p)
+    return targeton.compute_mutations(targeton_cfg.mutators, aux)
 
 
 def get_cdna_mutations(
@@ -111,10 +110,9 @@ def get_cdna_mutations(
     cdna: CDNA
 ) -> Dict[TargetonMutator, MutationCollection]:
     seq = cdna.get_subsequence_string(targeton_cfg.r2_range)
-    return Targeton(
-        seq, seq, StrandedPositionRange.to_plus_strand(
-            targeton_cfg.r2_range)).compute_mutations(
-                targeton_cfg.mutators)
+    spr = StrandedPositionRange.to_plus_strand(targeton_cfg.r2_range)
+    targeton = Targeton.build_without_variants(spr, seq)
+    return targeton.compute_mutations(targeton_cfg.mutators)
 
 
 def mut_coll_to_df(

--- a/src/valiant/cdna_cli.py
+++ b/src/valiant/cdna_cli.py
@@ -23,7 +23,7 @@ from typing import Callable, Dict, Optional, NoReturn
 import click
 import numpy as np
 import pandas as pd
-from .constants import CDS_ONLY_MUTATORS, MUTATOR_CATEGORIES
+from .constants import CDS_ONLY_MUTATORS, META_OLIGO_NAME, MUTATOR_CATEGORIES
 from .cli_utils import load_codon_table, validate_adaptor, set_logger
 from .common_cli import common_params, existing_file
 from .enums import TargetonMutator
@@ -36,7 +36,7 @@ from .models.codon_table import CodonTable
 from .models.metadata_table import MetadataTable
 from .models.mutated_sequences import MutationCollection
 from .models.oligo_generation_info import OligoGenerationInfo
-from .models.oligo_renderer import get_oligo_name
+from .models.oligo_renderer import get_oligo_name, get_oligo_names_from_dataframe
 from .models.oligo_template import MUTATION_TYPE_CATEGORIES_T, decode_mut_types_cat
 from .models.snv_table import AuxiliaryTables
 from .models.targeton import Targeton, CDSTargeton
@@ -220,15 +220,7 @@ def get_targeton_metadata_table(
     oligo_name_prefix = f"{targeton_cfg.seq_id}_{transcript_label}.{gene_label}_"
 
     # Generate oligonucleotide names
-    df['oligo_name'] = pd.Series(
-        df.apply(lambda r: get_oligo_name(
-            oligo_name_prefix,
-            r.var_type,
-            r.mutator,
-            r.mut_position,
-            r.ref if not pd.isnull(r.ref) else None,
-            r.new if not pd.isnull(r.new) else None), axis=1),
-        dtype='string')
+    df[META_OLIGO_NAME] = get_oligo_names_from_dataframe(oligo_name_prefix, df)
 
     # Drop field that would be discarded downstream
     df = df.drop('var_type', axis=1)

--- a/src/valiant/constants.py
+++ b/src/valiant/constants.py
@@ -56,6 +56,7 @@ META_MUTATOR = 'mutator'
 META_OLIGO_LENGTH = 'oligo_length'
 META_MSEQ = 'mseq'
 META_PAM_MUT_ANNOT = 'meta_pam_mut_annot'
+META_PAM_MUT_SGRNA_ID = 'meta_pam_mut_sgrna_id'
 
 # Temporary field names (not included in the final table)
 META_VAR_TYPE = 'var_type'
@@ -85,7 +86,8 @@ METADATA_FIELDS = [
     META_MUTATOR,
     META_OLIGO_LENGTH,
     META_MSEQ,
-    META_PAM_MUT_ANNOT
+    META_PAM_MUT_ANNOT,
+    META_PAM_MUT_SGRNA_ID
 ]
 
 METADATA_FIELDS_SET = set(METADATA_FIELDS)

--- a/src/valiant/constants.py
+++ b/src/valiant/constants.py
@@ -92,6 +92,8 @@ METADATA_FIELDS = [
 
 METADATA_FIELDS_SET = set(METADATA_FIELDS)
 
+ARRAY_SEPARATOR = ';'
+
 SRC_TYPES = [
     'ref',
     'cdna'

--- a/src/valiant/constants.py
+++ b/src/valiant/constants.py
@@ -28,31 +28,57 @@ CUSTOM_MUTATOR = 'custom'
 
 DEFAULT_OLIGO_MAX_LENGTH = 300
 
+# Valid metadata table field names
+META_OLIGO_NAME = 'oligo_name'
+META_SPECIES = 'species'
+META_ASSEMBLY = 'assembly'
+META_GENE_ID = 'gene_id'
+META_TRANSCRIPT_ID = 'transcript_id'
+META_SRC_TYPE = 'src_type'
+META_REF_CHR = 'ref_chr'
+META_REF_STRAND = 'ref_strand'
+META_REF_START = 'ref_start'
+META_REF_END = 'ref_end'
+META_REVC = 'revc'
+META_REF_SEQ = 'ref_seq'
+META_PAM_SEQ = 'pam_seq'
+META_VCF_ALIAS = 'vcf_alias'
+META_VCF_VAR_ID = 'vcf_var_id'
+META_MUT_POSITION = 'mut_position'
+META_REF = 'ref'
+META_NEW = 'new'
+META_REF_AA = 'ref_aa'
+META_ALT_AA = 'alt_aa'
+META_MUT_TYPE = 'mut_type'
+META_MUTATOR = 'mutator'
+META_OLIGO_LENGTH = 'oligo_length'
+META_MSEQ = 'mseq'
+
 METADATA_FIELDS = [
-    'oligo_name',
-    'species',
-    'assembly',
-    'gene_id',
-    'transcript_id',
-    'src_type',
-    'ref_chr',
-    'ref_strand',
-    'ref_start',
-    'ref_end',
-    'revc',
-    'ref_seq',
-    'pam_seq',
-    'vcf_alias',
-    'vcf_var_id',
-    'mut_position',
-    'ref',
-    'new',
-    'ref_aa',
-    'alt_aa',
-    'mut_type',
-    'mutator',
-    'oligo_length',
-    'mseq'
+    META_OLIGO_NAME,
+    META_SPECIES,
+    META_ASSEMBLY,
+    META_GENE_ID,
+    META_TRANSCRIPT_ID,
+    META_SRC_TYPE,
+    META_REF_CHR,
+    META_REF_STRAND,
+    META_REF_START,
+    META_REF_END,
+    META_REVC,
+    META_REF_SEQ,
+    META_PAM_SEQ,
+    META_VCF_ALIAS,
+    META_VCF_VAR_ID,
+    META_MUT_POSITION,
+    META_REF,
+    META_NEW,
+    META_REF_AA,
+    META_ALT_AA,
+    META_MUT_TYPE,
+    META_MUTATOR,
+    META_OLIGO_LENGTH,
+    META_MSEQ
 ]
 
 METADATA_FIELDS_SET = set(METADATA_FIELDS)

--- a/src/valiant/constants.py
+++ b/src/valiant/constants.py
@@ -54,6 +54,9 @@ META_MUTATOR = 'mutator'
 META_OLIGO_LENGTH = 'oligo_length'
 META_MSEQ = 'mseq'
 
+# Temporary field names (not included in the final table)
+META_VAR_TYPE = 'var_type'
+
 METADATA_FIELDS = [
     META_OLIGO_NAME,
     META_SPECIES,

--- a/src/valiant/constants.py
+++ b/src/valiant/constants.py
@@ -55,8 +55,8 @@ META_MUT_TYPE = 'mut_type'
 META_MUTATOR = 'mutator'
 META_OLIGO_LENGTH = 'oligo_length'
 META_MSEQ = 'mseq'
-META_PAM_MUT_ANNOT = 'meta_pam_mut_annot'
-META_PAM_MUT_SGRNA_ID = 'meta_pam_mut_sgrna_id'
+META_PAM_MUT_ANNOT = 'pam_mut_annot'
+META_PAM_MUT_SGRNA_ID = 'pam_mut_sgrna_id'
 
 # Temporary field names (not included in the final table)
 META_VAR_TYPE = 'var_type'

--- a/src/valiant/constants.py
+++ b/src/valiant/constants.py
@@ -26,6 +26,8 @@ DEFAULT_CODON_TABLE_FILE_NAME = 'default_codon_table.csv'
 REVCOMP_OLIGO_NAME_SUFFIX = '_rc'
 CUSTOM_MUTATOR = 'custom'
 
+MUTATION_TYPE_NON_CDS = 'ncd'
+
 DEFAULT_OLIGO_MAX_LENGTH = 300
 
 # Valid metadata table field names
@@ -53,6 +55,7 @@ META_MUT_TYPE = 'mut_type'
 META_MUTATOR = 'mutator'
 META_OLIGO_LENGTH = 'oligo_length'
 META_MSEQ = 'mseq'
+META_PAM_MUT_ANNOT = 'meta_pam_mut_annot'
 
 # Temporary field names (not included in the final table)
 META_VAR_TYPE = 'var_type'
@@ -81,7 +84,8 @@ METADATA_FIELDS = [
     META_MUT_TYPE,
     META_MUTATOR,
     META_OLIGO_LENGTH,
-    META_MSEQ
+    META_MSEQ,
+    META_PAM_MUT_ANNOT
 ]
 
 METADATA_FIELDS_SET = set(METADATA_FIELDS)

--- a/src/valiant/models/annotated_sequence.py
+++ b/src/valiant/models/annotated_sequence.py
@@ -190,6 +190,14 @@ class CDSAnnotatedSequencePair(AnnotatedSequencePair, Generic[VariantT]):
         return len(self) + self.cds_prefix_length + self.cds_suffix_length
 
     @property
+    def codon_count(self) -> int:
+        return self.ext_seq_length // 3
+
+    @property
+    def last_codon_index(self) -> int:
+        return self.codon_count - 1
+
+    @property
     def cds_ref_seq(self) -> str:
         return f"{self.cds_prefix}{self.ref_seq}{self.cds_suffix}"
 

--- a/src/valiant/models/annotated_sequence.py
+++ b/src/valiant/models/annotated_sequence.py
@@ -45,12 +45,12 @@ class BaseAnnotatedSequencePair(abc.ABC, Sized):
     @property
     @abc.abstractmethod
     def ext_ref_seq(self) -> str:
-        return self.ref_seq
+        pass
 
     @property
     @abc.abstractmethod
     def ext_alt_seq(self) -> str:
-        return self.alt_seq
+        pass
 
     @property
     @abc.abstractmethod
@@ -160,8 +160,16 @@ class CDSAnnotatedSequencePair(AnnotatedSequencePair):
             raise ValueError("Invalid length for in-frame sequence!")
 
     @property
+    def cds_prefix_length(self) -> int:
+        return len(self.cds_prefix)
+
+    @property
+    def cds_suffix_length(self) -> int:
+        return len(self.cds_suffix)
+
+    @property
     def ext_seq_length(self) -> int:
-        return len(self) + len(self.cds_prefix) + len(self.cds_suffix)
+        return len(self) + self.cds_prefix_length + self.cds_suffix_length
 
     @property
     def cds_ref_seq(self) -> str:

--- a/src/valiant/models/annotated_sequence.py
+++ b/src/valiant/models/annotated_sequence.py
@@ -125,7 +125,7 @@ class ReferenceAnnotatedSequencePair(BaseAnnotatedSequencePair):
 
 
 @dataclass(frozen=True)
-class AnnotatedSequencePair(BaseAnnotatedSequencePair):
+class AnnotatedSequencePair(BaseAnnotatedSequencePair, Generic[VariantT]):
     """Potentially mutated sequence (and its reference and variants)"""
 
     __slots__ = ['pos_range', 'ref_seq', '_alt_seq', '_variants']

--- a/src/valiant/models/annotated_sequence.py
+++ b/src/valiant/models/annotated_sequence.py
@@ -94,6 +94,9 @@ class BaseAnnotatedSequencePair(abc.ABC, Sized, Generic[RangeT, VariantT]):
         return self.get_codon_mutation_types_at_codons(
             codon_table, self.get_codon_indices(positions, **kwargs))
 
+    def get_variant_codon_indices(self, **kwargs) -> List[int]:
+        return self.get_codon_indices(self.variant_positions, **kwargs)
+
     def get_variant_mutation_types(self, codon_table: CodonTable, **kwargs) -> List[MutationType]:
         return self.get_codon_mutation_types_at(
             codon_table, self.variant_positions, **kwargs)

--- a/src/valiant/models/annotated_sequence.py
+++ b/src/valiant/models/annotated_sequence.py
@@ -29,13 +29,14 @@ from valiant.models.variant import SubstitutionVariant
 from valiant.utils import has_duplicates
 
 
+RangeT = TypeVar('RangeT', bound='StrandedPositionRange')
 VariantT = TypeVar('VariantT', bound='SubstitutionVariant')
 AnnotatedSequenceT = TypeVar('AnnotatedSequenceT', bound='BaseAnnotatedSequencePair')
 
 
 @dataclass(frozen=True)
-class BaseAnnotatedSequencePair(abc.ABC, Sized, Generic[VariantT]):
-    pos_range: StrandedPositionRange
+class BaseAnnotatedSequencePair(abc.ABC, Sized, Generic[RangeT, VariantT]):
+    pos_range: RangeT
     ref_seq: str
 
     def __len__(self) -> int:

--- a/src/valiant/models/annotated_sequence.py
+++ b/src/valiant/models/annotated_sequence.py
@@ -137,6 +137,7 @@ class AnnotatedSequencePair(BaseAnnotatedSequencePair):
         if len(self.ref_seq) != len(self.alt_seq):
             raise ValueError("Mismatching paired sequence lengths!")
 
+    @property
     def variant_count(self) -> int:
         return len(self.variants)
 

--- a/src/valiant/models/annotated_sequence.py
+++ b/src/valiant/models/annotated_sequence.py
@@ -159,7 +159,7 @@ class AnnotatedSequencePair(BaseAnnotatedSequencePair, Generic[VariantT]):
 
 
 @dataclass(frozen=True)
-class CDSAnnotatedSequencePair(AnnotatedSequencePair):
+class CDSAnnotatedSequencePair(AnnotatedSequencePair, Generic[VariantT]):
     """Potentially mutated CDS sequence (and its reference and variants)"""
 
     __slots__ = ['pos_range', 'ref_seq', '_alt_seq', '_variants', 'cds_prefix', 'cds_suffix']

--- a/src/valiant/models/annotated_sequence.py
+++ b/src/valiant/models/annotated_sequence.py
@@ -103,33 +103,6 @@ class BaseAnnotatedSequencePair(abc.ABC, Sized, Generic[RangeT, VariantT]):
 
 
 @dataclass(frozen=True)
-class ReferenceAnnotatedSequencePair(BaseAnnotatedSequencePair):
-    """Non-mutated sequence"""
-
-    __slots__ = ['pos_range', 'ref_seq']
-
-    @property
-    def alt_seq(self) -> str:
-        return self.ref_seq
-
-    @property
-    def ext_ref_seq(self) -> str:
-        return self.ref_seq
-
-    @property
-    def ext_alt_seq(self) -> str:
-        return self.alt_seq
-
-    @property
-    def variants(self) -> List[VariantT]:
-        return []
-
-    @property
-    def variant_count(self) -> int:
-        return 0
-
-
-@dataclass(frozen=True)
 class AnnotatedSequencePair(BaseAnnotatedSequencePair, Generic[VariantT]):
     """Potentially mutated sequence (and its reference and variants)"""
 

--- a/src/valiant/models/annotated_sequence.py
+++ b/src/valiant/models/annotated_sequence.py
@@ -30,6 +30,7 @@ from valiant.utils import has_duplicates
 
 
 VariantT = TypeVar('VariantT', bound='SubstitutionVariant')
+AnnotatedSequenceT = TypeVar('AnnotatedSequenceT', bound='BaseAnnotatedSequencePair')
 
 
 @dataclass(frozen=True)

--- a/src/valiant/models/annotated_sequence.py
+++ b/src/valiant/models/annotated_sequence.py
@@ -1,0 +1,147 @@
+########## LICENCE ##########
+# VaLiAnT
+# Copyright (C) 2020, 2021, 2022 Genome Research Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#############################
+
+from dataclasses import dataclass
+from itertools import groupby
+import logging
+from typing import Dict, List, Tuple
+
+from valiant.models.base import GenomicPosition, StrandedPositionRange
+from valiant.enums import MutationType
+from valiant.models.codon_table import CodonTable
+from valiant.models.variant import SubstitutionVariant
+
+
+@dataclass(frozen=True)
+class AnnotatedSequencePair:
+    __slots__ = ['pos_range', 'ref_seq', 'alt_seq', 'variants']
+
+    pos_range: StrandedPositionRange
+    ref_seq: str
+    alt_seq: str
+    variants: List[SubstitutionVariant]
+
+    def __post_init__(self) -> None:
+        if len(self.ref_seq) != len(self.alt_seq):
+            raise ValueError("Mismatching paired sequence lengths!")
+
+    def variant_count(self) -> int:
+        return len(self.variants)
+
+    @property
+    def variant_positions(self) -> List[GenomicPosition]:
+        return [x.genomic_position for x in self.variants]
+
+    @property
+    def ext_ref_seq(self) -> str:
+        return self.ref_seq
+
+    @property
+    def ext_alt_seq(self) -> str:
+        return self.alt_seq
+
+    @property
+    def _ext_offset(self) -> int:
+        """Offset converting genomic positions into extended sequence indices"""
+
+        return -self.pos_range.start
+
+    def _get_codon_indices(self, positions: List[GenomicPosition]) -> List[int]:
+        offset = self._ext_offset
+        return [(x.position + offset) // 3 for x in positions]
+
+    def get_codon_indices(self, positions: List[GenomicPosition], **kwargs) -> List[int]:
+        return self._get_codon_indices(positions)
+
+    def get_codon_mutation_types_at_codons(self, codon_table: CodonTable, codon_indices: List[int]) -> List[MutationType]:
+        return codon_table.get_mutation_types_at(
+            self.pos_range.strand,
+            self.ext_ref_seq,
+            self.ext_alt_seq,
+            codon_indices)
+
+    def get_codon_mutation_types_at(self, codon_table: CodonTable, positions: List[GenomicPosition], **kwargs) -> List[MutationType]:
+        return self.get_codon_mutation_types_at_codons(
+            codon_table, self.get_codon_indices(positions, **kwargs))
+
+    def get_variant_mutation_types(self, codon_table: CodonTable, **kwargs) -> List[MutationType]:
+        return self.get_codon_mutation_types_at(
+            codon_table, self.variant_positions, **kwargs)
+
+
+@dataclass(frozen=True)
+class CDSAnnotatedSequencePair(AnnotatedSequencePair):
+    __slots__ = ['pos_range', 'ref_seq', 'alt_seq', 'variants', 'cds_prefix', 'cds_suffix']
+
+    cds_prefix: str
+    cds_suffix: str
+
+    @property
+    def cds_ref_seq(self) -> str:
+        return f"{self.cds_prefix}{self.ref_seq}{self.cds_suffix}"
+
+    @property
+    def cds_alt_seq(self) -> str:
+        return f"{self.cds_prefix}{self.alt_seq}{self.cds_suffix}"
+
+    @property
+    def ext_ref_seq(self) -> str:
+        return self.cds_ref_seq
+
+    @property
+    def ext_alt_seq(self) -> str:
+        return self.cds_alt_seq
+
+    @property
+    def frame(self) -> int:
+        return len(self.cds_prefix)
+
+    @property
+    def _ext_offset(self) -> int:
+        """Offset converting genomic positions into extended sequence indices"""
+
+        return self.frame + super()._ext_offset
+
+    def _log_same_codon_variants(self) -> None:
+        offset = self._ext_offset
+
+        def get_variant_codon(variant: SubstitutionVariant) -> int:
+            return (variant.genomic_position.position - offset) // 3
+
+        def sort_key(t: Tuple[int, SubstitutionVariant]) -> int:
+            return t[0]
+
+        for codon_index, variants in groupby(sorted([
+            (get_variant_codon(variant), variant)
+            for variant in self.variants
+        ], key=sort_key), key=sort_key):
+            if len(list(variants)) > 1:
+                logging.error("Variants at %s affect the same codon (%d)!" % (
+                    ', '.join([str(x.genomic_position) for _, x in variants]),
+                    codon_index + 1))
+
+    def get_codon_indices(self, positions: List[GenomicPosition], **kwargs) -> List[int]:
+        codon_indices = self._get_codon_indices(positions)
+        no_duplicate_codons = kwargs.get('no_duplicate_codons', False)
+
+        # Verify no two variants affect the same codon
+        if no_duplicate_codons and len(set(codon_indices)) != len(codon_indices):
+            self._log_same_codon_variants()
+            raise ValueError("Variant affecting the same codon!")
+
+        return codon_indices

--- a/src/valiant/models/codon_table.py
+++ b/src/valiant/models/codon_table.py
@@ -18,7 +18,9 @@
 
 from __future__ import annotations
 from itertools import groupby
-from typing import Dict, List, Tuple
+from typing import Callable, Dict, List, Tuple
+
+from valiant.utils import validate_strand
 from ..globals import TRIPLET_RCS
 
 STOP_CODE = 'STOP'
@@ -80,6 +82,13 @@ class CodonTable:
 
     def translate_rc(self, codon: str) -> str:
         return self._codon2aa[TRIPLET_RCS[codon]]
+
+    def get_translate_f(self, strand: str) -> Callable[[str], str]:
+        validate_strand(strand)
+        return (
+            self.translate if strand == '+' else
+            self.translate_rc
+        )
 
     def get_translation_table(self) -> List[Tuple[str, str]]:
         return list(self._codon2aa.items())

--- a/src/valiant/models/codon_table.py
+++ b/src/valiant/models/codon_table.py
@@ -127,7 +127,8 @@ class CodonTable:
         tr = self.get_translate_f(strand)
 
         def get_mutation_type(codon_index: int) -> MutationType:
-            sl = slice(codon_index, codon_index + 3)
+            start: int = codon_index * 3
+            sl = slice(start, start + 3)
             return get_codon_mutation_type(tr, ref_seq[sl], alt_seq[sl])
 
         return list(map(get_mutation_type, codon_indices))

--- a/src/valiant/models/oligo_segment.py
+++ b/src/valiant/models/oligo_segment.py
@@ -74,9 +74,9 @@ class TargetonOligoSegment(OligoSegment[ITargeton], Generic[TargetonT]):
     def targeton(self) -> ITargeton:
         return self.region
 
-    def compute_mutations(self, aux: AuxiliaryTables) -> Dict[TargetonMutator, MutationCollection]:
+    def compute_mutations(self, aux: AuxiliaryTables, **kwargs) -> Dict[TargetonMutator, MutationCollection]:
         if isinstance(self.targeton, CDSTargeton):
-            return self.targeton.compute_mutations(self.mutators, aux)
+            return self.targeton.compute_mutations(self.mutators, aux, **kwargs)
         if isinstance(self.targeton, Targeton):
             return self.targeton.compute_mutations(self.mutators)
         raise TypeError("Invalid targeton type!")

--- a/src/valiant/models/oligo_segment.py
+++ b/src/valiant/models/oligo_segment.py
@@ -1,0 +1,86 @@
+########## LICENCE ##########
+# VaLiAnT
+# Copyright (C) 2020, 2021, 2022 Genome Research Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#############################
+
+import abc
+from dataclasses import dataclass
+from typing import Dict, FrozenSet, Generic, List, Optional
+
+from valiant.enums import MutationType, TargetonMutator
+
+from valiant.models.base import GenomicRange
+from valiant.models.codon_table import CodonTable
+from valiant.models.mutated_sequences import MutationCollection
+from valiant.models.snv_table import AuxiliaryTables
+from valiant.models.targeton import CDSTargeton, ITargeton, Targeton, TargetonT, PamProtected
+
+
+@dataclass
+class OligoSegment(abc.ABC, Generic[TargetonT]):
+    region: TargetonT
+
+    @property
+    def start(self) -> int:
+        return self.genomic_range.start
+
+    @property
+    def sequence(self) -> str:
+        return self.region.ref_seq
+
+    @property
+    def genomic_range(self) -> GenomicRange:
+        # This property can only be used for SGE libraries
+        return self.region.pos_range  # type: ignore
+
+    @property
+    def pam_protected_sequence(self) -> str:
+        return self.region.alt_seq
+
+    # See mypy bug: https://github.com/python/mypy/issues/12163
+    def get_pam_annotations(self, codon_table: CodonTable) -> List[Optional[MutationType]]:
+        is_pam: bool = issubclass(type(self.region), PamProtected)  # type: ignore
+        return (
+            self.region.get_pam_variant_annotations(codon_table) if is_pam else  # type: ignore
+            []
+        )
+
+
+@dataclass
+class InvariantOligoSegment(OligoSegment, Generic[TargetonT]):
+    __slots__ = ['region']
+
+
+@dataclass
+class TargetonOligoSegment(OligoSegment[ITargeton], Generic[TargetonT]):
+    __slots__ = ['region', 'mutators']
+
+    mutators: FrozenSet[TargetonMutator]
+
+    @property
+    def targeton(self) -> ITargeton:
+        return self.region
+
+    def compute_mutations(self, aux: AuxiliaryTables) -> Dict[TargetonMutator, MutationCollection]:
+        if isinstance(self.targeton, CDSTargeton):
+            return self.targeton.compute_mutations(self.mutators, aux)
+        if isinstance(self.targeton, Targeton):
+            return self.targeton.compute_mutations(self.mutators)
+        raise TypeError("Invalid targeton type!")
+
+    @property
+    def start(self) -> int:
+        return self.targeton.start

--- a/src/valiant/models/oligo_segment.py
+++ b/src/valiant/models/oligo_segment.py
@@ -22,11 +22,12 @@ from typing import Dict, FrozenSet, Generic, List, Optional
 
 from valiant.enums import MutationType, TargetonMutator
 
-from valiant.models.base import GenomicRange
+from valiant.models.base import GenomicRange, StrandedPositionRange
 from valiant.models.codon_table import CodonTable
 from valiant.models.mutated_sequences import MutationCollection
 from valiant.models.snv_table import AuxiliaryTables
 from valiant.models.targeton import CDSTargeton, ITargeton, Targeton, TargetonT, PamProtected
+from valiant.models.custom_variants import CustomVariant
 
 
 @dataclass
@@ -57,6 +58,9 @@ class OligoSegment(abc.ABC, Generic[TargetonT]):
             self.region.get_pam_variant_annotations(codon_table) if is_pam else  # type: ignore
             []
         )
+
+    def get_sgrna_ids(self, spr: StrandedPositionRange) -> FrozenSet[str]:
+        return self.region.get_sgrna_ids(spr)
 
 
 @dataclass

--- a/src/valiant/models/oligo_segment.py
+++ b/src/valiant/models/oligo_segment.py
@@ -27,7 +27,6 @@ from valiant.models.codon_table import CodonTable
 from valiant.models.mutated_sequences import MutationCollection
 from valiant.models.snv_table import AuxiliaryTables
 from valiant.models.targeton import CDSTargeton, ITargeton, Targeton, TargetonT, PamProtected
-from valiant.models.custom_variants import CustomVariant
 
 
 @dataclass

--- a/src/valiant/models/oligo_template.py
+++ b/src/valiant/models/oligo_template.py
@@ -303,7 +303,8 @@ class OligoTemplate:
             pd.concat([
                 self._get_mutation_collection(
                     i, segment, mutator, mutation_collection).get_metadata_table(options)
-                for mutator, mutation_collection in segment.compute_mutations(aux).items()
+                for mutator, mutation_collection in segment.compute_mutations(
+                    aux, sgrna_ids=self.sgrna_ids).items()
             ])
             for i, segment in self.target_segments
         ], ignore_index=True)

--- a/src/valiant/models/oligo_template.py
+++ b/src/valiant/models/oligo_template.py
@@ -159,7 +159,7 @@ class TargetonOligoSegment(OligoSegment):
 
     @property
     def start(self) -> int:
-        return self.targeton.pos_range.start
+        return self.targeton.start
 
 
 @dataclass(init=False)

--- a/src/valiant/models/oligo_template.py
+++ b/src/valiant/models/oligo_template.py
@@ -34,7 +34,7 @@ from .oligo_renderer import BaseOligoRenderer
 from .options import Options
 from .pam_protection import PamProtectedReferenceSequence
 from .snv_table import AuxiliaryTables
-from .variant import CustomVariant
+from .variant import BaseVariant, CustomVariant
 from ..constants import (
     CUSTOM_MUTATOR,
     META_OLIGO_NAME,
@@ -229,11 +229,20 @@ class OligoTemplate:
     def ref_segments(self) -> List[OligoSegment]:
         return self.segments
 
+    def _get_custom_variant_sgrna_ids(self, variant: CustomVariant) -> FrozenSet[str]:
+        spr = variant.get_ref_range(self.strand)
+        return frozenset().union(*[
+            segment.get_sgrna_ids(spr)
+            for segment in self.segments
+        ])
+
     def _compute_custom_variants(self) -> CustomVariantMutationCollection:
         return CustomVariantMutationCollection.from_variants([
             CustomVariantMutation(
-                variant, self.ref_seq.apply_variant(
-                    variant.base_variant, ref_check=False))
+                variant,
+                self.ref_seq.apply_variant(
+                    variant.base_variant, ref_check=False),
+                self._get_custom_variant_sgrna_ids(variant))
             for variant in self.custom_variants
         ])
 

--- a/src/valiant/models/oligo_template.py
+++ b/src/valiant/models/oligo_template.py
@@ -32,7 +32,17 @@ from .pam_protection import PamProtectedReferenceSequence
 from .snv_table import AuxiliaryTables
 from .targeton import BaseTargeton, CDSTargeton, Targeton
 from .variant import CustomVariant
-from ..constants import CUSTOM_MUTATOR
+from ..constants import (
+    CUSTOM_MUTATOR,
+    META_OLIGO_NAME,
+    META_VAR_TYPE,
+    META_MUT_POSITION,
+    META_REF,
+    META_NEW,
+    META_MUTATOR,
+    META_MSEQ,
+    META_OLIGO_LENGTH
+)
 from ..enums import MutationType, TargetonMutator
 from ..utils import get_constant_category
 
@@ -44,6 +54,17 @@ MUTATION_TYPE_LABELS: Dict[int, str] = {
 
 MUTATION_TYPE_CATEGORIES = sorted(MUTATION_TYPE_LABELS.values())
 MUTATION_TYPE_CATEGORIES_T = tuple(MUTATION_TYPE_CATEGORIES)
+
+EMPTY_MUTATION_TABLE_FIELDS = [
+    META_OLIGO_NAME,
+    META_VAR_TYPE,
+    META_MUT_POSITION,
+    META_REF,
+    META_NEW,
+    META_MUTATOR,
+    META_MSEQ,
+    META_OLIGO_LENGTH
+]
 
 
 def _decode_mut_type(x) -> str:
@@ -58,6 +79,10 @@ def decode_mut_types_cat(mut_type: pd.Series) -> pd.Categorical:
     return pd.Categorical(
         decode_mut_types(mut_type),
         categories=MUTATION_TYPE_CATEGORIES)
+
+
+def get_empty_mutation_table() -> pd.DataFrame:
+    return pd.DataFrame(columns=EMPTY_MUTATION_TABLE_FIELDS)
 
 
 class OligoSegment(abc.ABC):
@@ -340,16 +365,7 @@ class OligoTemplate:
 
     def get_mutation_table(self, aux: AuxiliaryTables, options: Options) -> pd.DataFrame:
         if not self.target_segments:
-            return pd.DataFrame(columns=[
-                'oligo_name',
-                'var_type',
-                'mut_position',
-                'ref',
-                'new',
-                'mutator',
-                'mseq',
-                'oligo_length'
-            ])
+            return get_empty_mutation_table()
 
         # Compute mutations per region
         region_mutations: pd.DataFrame = pd.concat([

--- a/src/valiant/models/oligo_template.py
+++ b/src/valiant/models/oligo_template.py
@@ -34,6 +34,7 @@ from .pam_protection import PamProtectedReferenceSequence
 from .snv_table import AuxiliaryTables
 from .variant import CustomVariant
 from ..constants import (
+    ARRAY_SEPARATOR,
     CUSTOM_MUTATOR,
     META_OLIGO_NAME,
     META_PAM_MUT_ANNOT,
@@ -89,7 +90,7 @@ def get_empty_mutation_table() -> pd.DataFrame:
 
 
 def encode_pam_mutation_types(mutation_types: Iterable[Optional[MutationType]]) -> str:
-    return ';'.join([
+    return ARRAY_SEPARATOR.join([
         MUTATION_TYPE_LABELS[x.value] if x is not None else MUTATION_TYPE_NON_CDS
         for x in mutation_types
     ])

--- a/src/valiant/models/oligo_template.py
+++ b/src/valiant/models/oligo_template.py
@@ -17,11 +17,9 @@
 #############################
 
 from __future__ import annotations
-import abc
 from dataclasses import dataclass
-from functools import partial
 from itertools import chain
-from typing import Callable, Dict, Iterable, List, Optional, Set, FrozenSet, Tuple
+from typing import Dict, Iterable, List, Optional, Set, FrozenSet, Tuple
 import numpy as np
 import pandas as pd
 from valiant.models.codon_table import CodonTable
@@ -29,12 +27,12 @@ from valiant.models.codon_table import CodonTable
 from valiant.models.oligo_segment import OligoSegment, TargetonOligoSegment
 from .base import GenomicRange, TranscriptInfo
 from .custom_variants import CustomVariantMutation, CustomVariantMutationCollection, CustomVariantOligoRenderer
-from .mutated_sequences import MutatedSequence, MutationCollection
+from .mutated_sequences import MutationCollection
 from .oligo_renderer import BaseOligoRenderer
 from .options import Options
 from .pam_protection import PamProtectedReferenceSequence
 from .snv_table import AuxiliaryTables
-from .variant import BaseVariant, CustomVariant
+from .variant import CustomVariant
 from ..constants import (
     CUSTOM_MUTATOR,
     META_OLIGO_NAME,

--- a/src/valiant/models/targeton.py
+++ b/src/valiant/models/targeton.py
@@ -57,6 +57,21 @@ class BaseTargeton(abc.ABC):
     def sequence(self) -> str:
         pass
 
+    @property
+    @abc.abstractmethod
+    def seq(self) -> str:
+        pass
+
+    @property
+    @abc.abstractmethod
+    def pam_seq(self) -> str:
+        pass
+
+    @property
+    @abc.abstractmethod
+    def start(self) -> int:
+        pass
+
     def _get_mutator_method(self, mutator: TargetonMutator):
         return getattr(self, f"get_{mutator.value.replace('-', '_')}_mutations")
 
@@ -99,6 +114,18 @@ class Targeton(AnnotatedSequencePair, BaseTargeton, Generic[VariantT]):
     @property
     def sequence(self) -> str:
         return self.alt_seq
+
+    @property
+    def seq(self) -> str:
+        return self.ref_seq
+
+    @property
+    def pam_seq(self) -> str:
+        return self.alt_seq
+
+    @property
+    def start(self) -> int:
+        return self.pos_range.start
 
     @classmethod
     def build_without_variants(
@@ -160,6 +187,14 @@ class CDSTargeton(CDSAnnotatedSequencePair, BaseTargeton, Generic[VariantT]):
 
     @property
     def sequence(self) -> str:
+        return self.alt_seq
+
+    @property
+    def seq(self) -> str:
+        return self.ref_seq
+
+    @property
+    def pam_seq(self) -> str:
         return self.alt_seq
 
     @property
@@ -371,3 +406,13 @@ class PamProtCDSTargeton(CDSTargeton[PamVariant], PamProtected):
 
     def compute_mutations(self, mutators: FrozenSet[TargetonMutator], aux: AuxiliaryTables) -> Dict[TargetonMutator, MutationCollection]:
         return super().compute_mutations(mutators, aux)
+
+
+@dataclass(frozen=True)
+class CDNATargeton(Targeton[PamVariant]):
+    __slots__ = ['pos_range', 'ref_seq']
+
+
+@dataclass(frozen=True)
+class CDNACDSTargeton(CDSTargeton[PamVariant]):
+    __slots__ = ['pos_range', 'ref_seq', 'cds_prefix', 'cds_suffix']

--- a/src/valiant/models/targeton.py
+++ b/src/valiant/models/targeton.py
@@ -286,8 +286,7 @@ class CDSTargeton(ITargeton[CDSAnnotatedSequencePair], Generic[VariantT, RangeT]
         snv_joint.mut_position -= self.start
 
         # Wrap complete SNV metadata in a collection
-        return MutationCollection(
-            df=snv_joint, mutations=snvs.mutations)
+        return MutationCollection(snv_joint)
 
     def _get_snvres(self, aux: AuxiliaryTables, snvs: pd.DataFrame) -> MutationCollection:
         df: pd.DataFrame = aux.snvre_table.get_snvres(
@@ -300,11 +299,7 @@ class CDSTargeton(ITargeton[CDSAnnotatedSequencePair], Generic[VariantT, RangeT]
                     'mut_type': 'mut_type'
                 })
 
-        # TODO: avoid generating mutation list when possible
-        return MutationCollection(df=df, mutations=[
-            SingleCodonMutatedSequence(r.mut_position, r.mseq, r.ref, r.new)
-            for r in df.itertuples()
-        ])
+        return MutationCollection(df)
 
     def _get_codon_mutations(self, codon_table: CodonTable, aa: str) -> MutationCollection:
 
@@ -357,10 +352,7 @@ class CDSTargeton(ITargeton[CDSAnnotatedSequencePair], Generic[VariantT, RangeT]
             raise RuntimeError("Auxiliary tables not provided!")
         df: pd.DataFrame = aux_tables.all_aa_table.get_subs(
             self.pos_range, self.frame, self.sequence)
-        return MutationCollection(df=df, mutations=[
-            SingleCodonMutatedSequence(r.mut_position, r.mseq, r.ref, r.new)
-            for r in df.itertuples()
-        ])
+        return MutationCollection(df)
 
     def compute_mutations(self, mutators: FrozenSet[TargetonMutator], aux: AuxiliaryTables) -> Dict[TargetonMutator, MutationCollection]:
 

--- a/src/valiant/models/targeton.py
+++ b/src/valiant/models/targeton.py
@@ -170,7 +170,6 @@ class CDSTargeton(BaseTargeton):
 
     def _add_snv_metadata(
         self,
-        aux: AuxiliaryTables,
         snv_meta_full: pd.DataFrame,
         snvs: MutationCollection
     ) -> MutationCollection:
@@ -304,7 +303,7 @@ class CDSTargeton(BaseTargeton):
                 reset_index=False)
 
             # Attach pre-computed metadata to SNV's
-            snvs: MutationCollection = self._add_snv_metadata(aux, snv_meta_full, mutations[TargetonMutator.SNV])
+            snvs: MutationCollection = self._add_snv_metadata(snv_meta_full, mutations[TargetonMutator.SNV])
             mutations[TargetonMutator.SNV] = snvs
 
             # TODO: refactor dispatch

--- a/src/valiant/models/targeton.py
+++ b/src/valiant/models/targeton.py
@@ -18,7 +18,7 @@
 
 from __future__ import annotations
 import abc
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from functools import partial
 from typing import Any, Callable, ClassVar, Dict, Generic, List, FrozenSet, Optional, Type, TypeVar
 import numpy as np
@@ -28,7 +28,7 @@ from valiant.models.annotated_sequence import AnnotatedSequencePair, AnnotatedSe
 from valiant.models.base import GenomicRange, StrandedPositionRange
 from valiant.models.pam_protection import PamProtectedReferenceSequence, PamVariant
 from .codon_table import CodonTable, STOP_CODE
-from ..constants import GENERIC_MUTATORS, CDS_ONLY_MUTATORS, META_MUT_POSITION, META_PAM_MUT_SGRNA_ID, META_REF, ARRAY_SEPARATOR
+from ..constants import GENERIC_MUTATORS, CDS_ONLY_MUTATORS
 from .mutated_sequences import (
     DeletionMutatedSequence,
     Deletion1MutatedSequence,

--- a/src/valiant/models/targeton.py
+++ b/src/valiant/models/targeton.py
@@ -509,10 +509,6 @@ class PamProtCDSTargeton(CDSTargeton[PamVariant, GenomicRange], PamProtected):
     def has_pam_variants(self) -> bool:
         return self.variant_count > 0
 
-    @classmethod
-    def from_annotated_sequence(cls, annotated_sequence: CDSAnnotatedSequencePair) -> PamProtCDSTargeton:
-        return cls(annotated_sequence, codon_to_sgrna_id)
-
     def set_metadata_sgrna_ids(self, mutations: MutationCollection) -> None:
         return set_metadata_sgrna_ids(self.frame, self._codon_to_sgrna_id, mutations.df)
 

--- a/src/valiant/models/targeton.py
+++ b/src/valiant/models/targeton.py
@@ -19,7 +19,7 @@
 from __future__ import annotations
 import abc
 from dataclasses import dataclass
-from typing import Callable, ClassVar, Dict, Generic, List, FrozenSet, Optional
+from typing import Callable, ClassVar, Dict, Generic, List, FrozenSet, Optional, Type, TypeVar
 import numpy as np
 import pandas as pd
 
@@ -41,6 +41,11 @@ from .snv_table import AuxiliaryTables
 from ..enums import MutationType, TargetonMutator, VariantType
 from ..string_mutators import delete_non_overlapping_3_offset, replace_codons_const
 from ..utils import get_constant_category, get_out_of_frame_offset
+
+
+TargetonT = TypeVar('TargetonT', bound='ITargeton')
+NonCDSTargetonT = TypeVar('NonCDSTargetonT', bound='Targeton')
+CDSTargetonT = TypeVar('CDSTargetonT', bound='CDSTargeton')
 
 
 def get_snv_mutations(sequence: str) -> MutationCollection:
@@ -150,17 +155,17 @@ class Targeton(ITargeton[AnnotatedSequencePair], Generic[VariantT, RangeT]):
 
     @classmethod
     def build_without_variants(
-        cls,
+        cls: Type[NonCDSTargetonT],
         pos_range: RangeT,
         ref_seq: str
-    ) -> Targeton:
+    ) -> NonCDSTargetonT:
         return cls(AnnotatedSequencePair(pos_range, ref_seq, ref_seq, []))
 
     @classmethod
     def from_pam_seq(
-        cls,
+        cls: Type[NonCDSTargetonT],
         pam_seq: PamProtectedReferenceSequence
-    ) -> Targeton:
+    ) -> NonCDSTargetonT:
         return cls(AnnotatedSequencePair(
             pam_seq.genomic_range,
             pam_seq.sequence,
@@ -183,22 +188,22 @@ class CDSTargeton(ITargeton[CDSAnnotatedSequencePair], Generic[VariantT, RangeT]
 
     @classmethod
     def build_without_variants(
-        cls,
+        cls: Type[CDSTargetonT],
         pos_range: RangeT,
         ref_seq: str,
         cds_prefix: str,
         cds_suffix: str
-    ) -> CDSTargeton:
+    ) -> CDSTargetonT:
         return cls(CDSAnnotatedSequencePair(
             pos_range, ref_seq, ref_seq, [], cds_prefix, cds_suffix))
 
     @classmethod
     def from_pam_seq(
-        cls,
+        cls: Type[CDSTargetonT],
         pam_seq: PamProtectedReferenceSequence,
         cds_prefix: str,
         cds_suffix: str
-    ) -> CDSTargeton:
+    ) -> CDSTargetonT:
         return cls(CDSAnnotatedSequencePair(
             pam_seq.genomic_range,
             pam_seq.sequence,

--- a/src/valiant/models/targeton.py
+++ b/src/valiant/models/targeton.py
@@ -406,13 +406,3 @@ class PamProtCDSTargeton(CDSTargeton[PamVariant], PamProtected):
 
     def compute_mutations(self, mutators: FrozenSet[TargetonMutator], aux: AuxiliaryTables) -> Dict[TargetonMutator, MutationCollection]:
         return super().compute_mutations(mutators, aux)
-
-
-@dataclass(frozen=True)
-class CDNATargeton(Targeton[PamVariant]):
-    __slots__ = ['pos_range', 'ref_seq']
-
-
-@dataclass(frozen=True)
-class CDNACDSTargeton(CDSTargeton[PamVariant]):
-    __slots__ = ['pos_range', 'ref_seq', 'cds_prefix', 'cds_suffix']

--- a/src/valiant/models/targeton.py
+++ b/src/valiant/models/targeton.py
@@ -19,7 +19,6 @@
 from __future__ import annotations
 import abc
 from collections.abc import Sized
-from dataclasses import dataclass
 from typing import Callable, ClassVar, Dict, List, FrozenSet, Optional
 import numpy as np
 import pandas as pd
@@ -34,10 +33,8 @@ from .mutated_sequences import (
     SingleNucleotideMutatedSequence,
     SingleCodonMutatedSequence
 )
-from .base import StrandedPositionRange, GenomicRange
-from .cdna import CDNA
+from .base import StrandedPositionRange
 from .pam_protection import PamProtectedReferenceSequence
-from .sequences import Sequence
 from .snv_table import AuxiliaryTables
 from ..enums import TargetonMutator, VariantType
 from ..string_mutators import delete_non_overlapping_3_offset, replace_codons_const

--- a/src/valiant/models/targeton.py
+++ b/src/valiant/models/targeton.py
@@ -23,8 +23,8 @@ from typing import Callable, ClassVar, Dict, Generic, List, FrozenSet, Optional
 import numpy as np
 import pandas as pd
 
-from valiant.models.annotated_sequence import AnnotatedSequencePair, AnnotatedSequenceT, CDSAnnotatedSequencePair, VariantT
-from valiant.models.base import StrandedPositionRange
+from valiant.models.annotated_sequence import AnnotatedSequencePair, AnnotatedSequenceT, CDSAnnotatedSequencePair, RangeT, VariantT
+from valiant.models.base import GenomicRange, StrandedPositionRange
 from valiant.models.pam_protection import PamProtectedReferenceSequence, PamVariant
 from .codon_table import CodonTable, STOP_CODE
 from ..constants import GENERIC_MUTATORS, CDS_ONLY_MUTATORS
@@ -129,7 +129,7 @@ class ITargeton(BaseTargeton, Generic[AnnotatedSequenceT], abc.ABC):
 
 
 @dataclass(frozen=True)
-class Targeton(ITargeton[AnnotatedSequencePair], Generic[VariantT]):
+class Targeton(ITargeton[AnnotatedSequencePair], Generic[VariantT, RangeT]):
     __slots__ = ['annotated_seq']
 
     @property
@@ -151,7 +151,7 @@ class Targeton(ITargeton[AnnotatedSequencePair], Generic[VariantT]):
     @classmethod
     def build_without_variants(
         cls,
-        pos_range: StrandedPositionRange,
+        pos_range: RangeT,
         ref_seq: str
     ) -> Targeton:
         return cls(AnnotatedSequencePair(pos_range, ref_seq, ref_seq, []))
@@ -172,7 +172,7 @@ class Targeton(ITargeton[AnnotatedSequencePair], Generic[VariantT]):
 
 
 @dataclass(frozen=True)
-class CDSTargeton(ITargeton[CDSAnnotatedSequencePair], Generic[VariantT]):
+class CDSTargeton(ITargeton[CDSAnnotatedSequencePair], Generic[VariantT, RangeT]):
     __slots__ = ['annotated_seq']
 
     MUTATORS: ClassVar[FrozenSet[TargetonMutator]] = GENERIC_MUTATORS | CDS_ONLY_MUTATORS
@@ -184,7 +184,7 @@ class CDSTargeton(ITargeton[CDSAnnotatedSequencePair], Generic[VariantT]):
     @classmethod
     def build_without_variants(
         cls,
-        pos_range: StrandedPositionRange,
+        pos_range: RangeT,
         ref_seq: str,
         cds_prefix: str,
         cds_suffix: str
@@ -415,7 +415,7 @@ class PamProtected(abc.ABC):
 
 
 @dataclass(frozen=True)
-class PamProtTargeton(Targeton[PamVariant], PamProtected):
+class PamProtTargeton(Targeton[PamVariant, GenomicRange], PamProtected):
     __slots__ = ['annotated_seq']
 
     def get_pam_variant_annotations(self, codon_table: CodonTable) -> List[Optional[MutationType]]:
@@ -424,7 +424,7 @@ class PamProtTargeton(Targeton[PamVariant], PamProtected):
 
 
 @dataclass(frozen=True)
-class PamProtCDSTargeton(CDSTargeton[PamVariant], PamProtected):
+class PamProtCDSTargeton(CDSTargeton[PamVariant, GenomicRange], PamProtected):
     __slots__ = ['annotated_seq']
 
     def __post_init__(self) -> None:

--- a/src/valiant/models/variant.py
+++ b/src/valiant/models/variant.py
@@ -24,7 +24,7 @@ from typing import Dict, List, Optional, Set, Tuple, ClassVar, Any, Callable
 import pandas as pd
 from pyranges import PyRanges
 from pysam import VariantRecord
-from .base import GenomicPosition, GenomicRange
+from .base import GenomicPosition, GenomicRange, StrandedPositionRange
 from .refseq_repository import ReferenceSequenceRepository
 from .sequences import ReferenceSequence
 from ..enums import VariantType, VariantClassification
@@ -163,6 +163,12 @@ class CustomVariant:
     base_variant: BaseVariant
     vcf_alias: Optional[str]
     vcf_variant_id: Optional[str]
+
+    def get_ref_range(self, strand: str) -> StrandedPositionRange:
+        start: int = self.base_variant.genomic_position.position
+        ref_length: int = len(getattr(self.base_variant, 'ref', ''))
+        end: int = start + (ref_length if ref_length > 1 else 0)
+        return StrandedPositionRange(start, end, strand)
 
 
 VAR_TYPE_CONSTRUCTOR: Dict[int, Callable[[Any], BaseVariant]] = {

--- a/src/valiant/sge_cli.py
+++ b/src/valiant/sge_cli.py
@@ -146,7 +146,6 @@ def get_oligo_template(
             get_cds_extension_sequence(exg_gr_pair[0]),
             get_cds_extension_sequence(exg_gr_pair[1]))
 
-    # TODO: check unhandled branch!
     def get_targeton(region_pam_seq: PamProtectedReferenceSequence) -> ITargeton:
         if cds:
             exg_gr_pair: Optional[GenomicRangePair] = cds.get_cds_extensions(

--- a/src/valiant/sge_cli.py
+++ b/src/valiant/sge_cli.py
@@ -112,31 +112,6 @@ def get_oligo_template(
 
     # 2. Get constant regions
 
-    def get_constant_targeton(gr: GenomicRange) -> PamProtTargeton:
-        return PamProtTargeton.from_pam_seq(
-            pam_ref_seq.get_subsequence(gr))
-
-    def get_constant_segment(gr: GenomicRange) -> InvariantOligoSegment:
-        return InvariantOligoSegment(get_constant_targeton(gr))
-
-    def get_constant_region_segment(gr: Optional[GenomicRange]) -> Optional[InvariantOligoSegment]:
-        return InvariantOligoSegment(get_constant_targeton(gr)) if gr else None
-
-    const_region_1: Optional[InvariantOligoSegment] = get_constant_region_segment(rsr.const_region_1)
-    const_region_2: Optional[InvariantOligoSegment] = get_constant_region_segment(rsr.const_region_2)
-
-    # 3. Get potential target regions
-
-    def get_cds_extension_sequence(genomic_range: Optional[GenomicRange]) -> str:
-        if genomic_range is None:
-            return ''
-
-        sequence: Optional[str] = ref.get_genomic_range_sequence(genomic_range)
-        if sequence is None:
-            raise RuntimeError("CDS extension sequence not found!")
-
-        return sequence
-
     def get_cds_targeton(
         region_pam_seq: PamProtectedReferenceSequence,
         exg_gr_pair: GenomicRangePair
@@ -154,11 +129,30 @@ def get_oligo_template(
                 return get_cds_targeton(region_pam_seq, exg_gr_pair)
         return PamProtTargeton.from_pam_seq(region_pam_seq)
 
+    def get_constant_region_segment(gr: Optional[GenomicRange]) -> Optional[InvariantOligoSegment]:
+        return InvariantOligoSegment(
+            get_targeton(pam_ref_seq.get_subsequence(gr))) if gr else None
+
+    const_region_1: Optional[InvariantOligoSegment] = get_constant_region_segment(rsr.const_region_1)
+    const_region_2: Optional[InvariantOligoSegment] = get_constant_region_segment(rsr.const_region_2)
+
+    # 3. Get potential target regions
+
+    def get_cds_extension_sequence(genomic_range: Optional[GenomicRange]) -> str:
+        if genomic_range is None:
+            return ''
+
+        sequence: Optional[str] = ref.get_genomic_range_sequence(genomic_range)
+        if sequence is None:
+            raise RuntimeError("CDS extension sequence not found!")
+
+        return sequence
+
     def get_oligo_segment(trr: TargetReferenceRegion) -> OligoSegment:
         region_pam_seq = pam_ref_seq.get_subsequence(trr.genomic_range)
         return (
             TargetonOligoSegment(get_targeton(region_pam_seq), trr.mutators) if trr.mutators else
-            get_constant_segment(trr.genomic_range)
+            get_constant_region_segment(trr.genomic_range)
         )
 
     def get_transcript_info(genomic_ranges: Iterable[GenomicRange]) -> Optional[TranscriptInfo]:

--- a/src/valiant/sge_cli.py
+++ b/src/valiant/sge_cli.py
@@ -36,7 +36,7 @@ from .models.refseq_ranges import genomic_ranges_to_pyranges, ReferenceSequenceR
 from .models.refseq_repository import fetch_reference_sequences, ReferenceSequenceRepository
 from .models.sequences import ReferenceSequence
 from .models.snv_table import AuxiliaryTables
-from .models.targeton import BaseTargeton, CDSTargeton, Targeton
+from .models.targeton import BaseTargeton, CDSTargeton, PamProtCDSTargeton, Targeton
 from .models.variant import CustomVariant, VariantRepository
 from .common_cli import common_params, existing_file
 from .cli_utils import load_codon_table, validate_adaptor, set_logger
@@ -131,8 +131,8 @@ def get_oligo_template(
     def get_cds_targeton(
         region_pam_seq: PamProtectedReferenceSequence,
         exg_gr_pair: GenomicRangePair
-    ) -> CDSTargeton:
-        return CDSTargeton.from_pam_seq(
+    ) -> PamProtCDSTargeton:
+        return PamProtCDSTargeton.from_pam_seq(
             region_pam_seq,
             get_cds_extension_sequence(exg_gr_pair[0]),
             get_cds_extension_sequence(exg_gr_pair[1]))

--- a/src/valiant/sgrna_utils.py
+++ b/src/valiant/sgrna_utils.py
@@ -71,3 +71,44 @@ def set_metadata_sgrna_ids(frame: int, codon_to_sgrna_ids: Dict[int, str], metad
 
     metadata[META_PAM_MUT_SGRNA_ID] = metadata.apply(
         get_sgrna_id_str, axis=1).astype('string')
+
+
+def get_codon_index(seq_frame: int, seq_start: int, x: int) -> int:
+    return (x + seq_frame - seq_start) // 3
+
+
+def get_codon_indices_in_range(
+    seq_frame: int,
+    seq_start: int,
+    seq_end: int,
+    target_start: int,
+    target_end: int
+) -> List[int]:
+    """Get the indices of the codons spanned by the target range, if any"""
+
+    def _get_codon_index(x: int) -> int:
+        return get_codon_index(seq_frame, seq_start, x)
+
+    # NOTE: in a `PositionRange`, `end` is guaranteed to be larger than `start`
+    assert seq_end >= seq_start and target_end >= target_start
+
+    if target_end < seq_start or target_start > seq_end:
+        return []
+
+    # Get first codon index
+    codon_start: int = 0 if target_start <= seq_start else _get_codon_index(target_start)
+
+    if target_end == target_start:
+        return [codon_start]
+
+    # Get last codon index
+    codon_end: int = (
+        _get_codon_index(seq_end) if target_end >= seq_end else
+        _get_codon_index(target_end)
+    )
+
+    # Generate full codon index range
+    return (
+        [codon_start] if codon_end == codon_start else
+        list(range(codon_start, codon_end + 1))
+    )

--- a/src/valiant/sgrna_utils.py
+++ b/src/valiant/sgrna_utils.py
@@ -50,12 +50,16 @@ def get_sgrna_ids_from_row(frame: int, codon_to_sgrna_ids: Dict[int, str], r: pd
     return get_sgrna_ids(frame, codon_to_sgrna_ids, r[META_MUT_POSITION], mut_ref)
 
 
+def sgrna_ids_to_string(sgrna_ids: Set[str]) -> str:
+    return ARRAY_SEPARATOR.join(sorted(sgrna_ids))
+
+
 def get_sgrna_ids_from_row_as_string(frame: int, codon_to_sgrna_ids: Dict[int, str], r: pd.Series) -> str:
     """Concatenated sgRNA ID's or empty string"""
 
-    return ARRAY_SEPARATOR.join(sorted(
+    return sgrna_ids_to_string(
         get_sgrna_ids_from_row(
-            frame, codon_to_sgrna_ids, r)))
+            frame, codon_to_sgrna_ids, r))
 
 
 def set_metadata_sgrna_ids(frame: int, codon_to_sgrna_ids: Dict[int, str], metadata: pd.DataFrame) -> None:

--- a/src/valiant/sgrna_utils.py
+++ b/src/valiant/sgrna_utils.py
@@ -1,0 +1,69 @@
+########## LICENCE ##########
+# VaLiAnT
+# Copyright (C) 2020, 2021, 2022 Genome Research Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#############################
+
+from typing import Dict, List, Optional, Set
+import pandas as pd
+from .constants import META_MUT_POSITION, META_REF, META_PAM_MUT_SGRNA_ID, ARRAY_SEPARATOR
+
+
+def get_sgrna_ids(frame: int, codon_to_sgrna_ids: Dict[int, str], mut_pos: int, mut_ref: Optional[str]) -> Set[str]:
+    """List the identifiers of the sgRNA's whose variants map to codons altered by the mutation"""
+
+    start: int = mut_pos + frame
+    codon_start: int = start // 3
+    ref_length: int = len(mut_ref) if mut_ref else 0
+
+    return (
+        {
+            codon_to_sgrna_ids[codon_index]
+            for codon_index in range(codon_start, ((start + ref_length) // 3) + 1)
+            if codon_index in codon_to_sgrna_ids
+        } if ref_length > 1 else
+        {codon_to_sgrna_ids[codon_start]} if codon_start in codon_to_sgrna_ids else
+        set()
+    )
+
+
+def get_sgrna_ids_from_row(frame: int, codon_to_sgrna_ids: Dict[int, str], r: pd.Series) -> Set[str]:
+    """
+    List the identifiers of the sgRNA's whose variants map to codons altered by the mutation
+
+    Metadata table row expected, with relative start position and reference sequence.
+    """
+
+    mut_ref: Optional[str] = r[META_REF] if not pd.isna(r[META_REF]) else None
+    return get_sgrna_ids(frame, codon_to_sgrna_ids, r[META_MUT_POSITION], mut_ref)
+
+
+def get_sgrna_ids_from_row_as_string(frame: int, codon_to_sgrna_ids: Dict[int, str], r: pd.Series) -> str:
+    """Concatenated sgRNA ID's or empty string"""
+
+    return ARRAY_SEPARATOR.join(sorted(
+        get_sgrna_ids_from_row(
+            frame, codon_to_sgrna_ids, r)))
+
+
+def set_metadata_sgrna_ids(frame: int, codon_to_sgrna_ids: Dict[int, str], metadata: pd.DataFrame) -> None:
+    """Set the sgRNA ID field in the metadata table (SGE only)"""
+
+    def get_sgrna_id_str(r: pd.Series) -> str:
+        return get_sgrna_ids_from_row_as_string(
+            frame, codon_to_sgrna_ids, r)
+
+    metadata[META_PAM_MUT_SGRNA_ID] = metadata.apply(
+        get_sgrna_id_str, axis=1).astype('string')

--- a/src/valiant/snv.py
+++ b/src/valiant/snv.py
@@ -158,12 +158,7 @@ def _build_base_snv_table() -> pd.DataFrame:
 
 
 def build_snv_table(base_snv_table: pd.DataFrame, codon_table: CodonTable, strand: str) -> pd.DataFrame:
-    validate_strand(strand)
-
-    tr: Callable[[str], str] = (
-        codon_table.translate if strand == '+' else
-        codon_table.translate_rc
-    )
+    tr = codon_table.get_translate_f(strand)
 
     df: pd.DataFrame = base_snv_table.copy()
 

--- a/src/valiant/utils.py
+++ b/src/valiant/utils.py
@@ -140,3 +140,7 @@ def get_source_type_column(src_type: str, n: int) -> pd.Series:
 
 def repr_enum_list(enums: Iterable[Enum]) -> str:
     return ', '.join(str(e.value) for e in enums)
+
+
+def has_duplicates(items: List[int]) -> bool:
+    return len(set(items)) != len(items)

--- a/tests/unit_tests/test_annotated_sequence.py
+++ b/tests/unit_tests/test_annotated_sequence.py
@@ -1,0 +1,70 @@
+########## LICENCE ##########
+# VaLiAnT
+# Copyright (C) 2020, 2021, 2022 Genome Research Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#############################
+
+from contextlib import nullcontext
+import pytest
+from valiant.models.annotated_sequence import AnnotatedSequencePair, CDSAnnotatedSequencePair
+from valiant.models.base import GenomicPosition, StrandedPositionRange
+from valiant.models.variant import SubstitutionVariant
+from .utils import load_codon_table
+
+
+codon_table = load_codon_table()
+
+
+def test_get_variant_mutation_types():
+
+    # Generate annotated sequence pair
+    genomic_positions = [100, 101]
+    sp = AnnotatedSequencePair(
+        StrandedPositionRange(100, 105, '+'),
+        'AAGTACG',
+        'CCGTACG', [
+            SubstitutionVariant(GenomicPosition('X', pos), 'A', 'C')
+            for pos in genomic_positions
+        ])
+
+    print(sp)
+
+    # Retrieve mutation types
+    mutation_types = sp.get_variant_mutation_types(codon_table)
+
+    assert len(mutation_types) == len(genomic_positions)
+
+
+@pytest.mark.parametrize('no_duplicate_codons', [True, False])
+def test_cds_get_variant_mutation_types(no_duplicate_codons):
+
+    # Generate annotated sequence pair
+    genomic_positions = [100, 101]
+    sp = CDSAnnotatedSequencePair(
+        StrandedPositionRange(100, 105, '+'),
+        'AAGTACG',
+        'CCGTACG', [
+            SubstitutionVariant(GenomicPosition('X', pos), 'A', 'C')
+            for pos in genomic_positions
+        ],
+        'T',
+        'C')
+
+    # Retrieve mutation types
+    with pytest.raises(ValueError) if no_duplicate_codons else nullcontext():
+        mutation_types = sp.get_variant_mutation_types(
+            codon_table, no_duplicate_codons=no_duplicate_codons)
+
+        assert len(mutation_types) == len(genomic_positions)

--- a/tests/unit_tests/test_cdna_cli.py
+++ b/tests/unit_tests/test_cdna_cli.py
@@ -150,7 +150,7 @@ def test_mut_coll_to_df():
         get_empty_aa_column,
         start_pos,
         TargetonMutator.SNV,
-        MutationCollection(df=raw_df.copy(deep=True)))
+        MutationCollection(raw_df.copy(deep=True)))
 
     # Check mutation position field
     assert df.mut_position.min() == raw_df.mut_position.min() + start_pos

--- a/tests/unit_tests/test_codon_replacements.py
+++ b/tests/unit_tests/test_codon_replacements.py
@@ -21,6 +21,7 @@ import pytest
 from valiant.enums import VariantType
 from valiant.models.base import GenomicRange
 from valiant.models.pam_protection import PamProtectedReferenceSequence
+from valiant.models.sequences import ReferenceSequence
 from valiant.models.targeton import CDSTargeton
 from .utils import get_aux_tables, seq2triplets
 
@@ -45,7 +46,9 @@ def test_get_snvre_aa_mutations(aa, strand, seq, exp_mseq):
 
     # Generate target
     gr = GenomicRange('X', 10, 10 + len(seq) - 1, strand)
-    t = CDSTargeton.from_pam_seq(PamProtectedReferenceSequence(seq, gr, seq), '', '')
+    pam_seq = PamProtectedReferenceSequence.from_reference_sequence(
+        ReferenceSequence(seq, gr), set())
+    t = CDSTargeton.from_pam_seq(pam_seq, '', '')
 
     # Generate codon substitution mutations
     mc = getattr(t, CONST_CODON_METHODS[aa])(aux_tables=aux)

--- a/tests/unit_tests/test_custom_variants.py
+++ b/tests/unit_tests/test_custom_variants.py
@@ -46,7 +46,7 @@ def test_custom_variant_mutation_init(variant):
     custom_variant = CustomVariant(variant, 'vcf_alias', 'VARIANT_ID')
 
     # Initialise custom variant mutation
-    CustomVariantMutation(custom_variant, seq)
+    CustomVariantMutation(custom_variant, seq, frozenset())
 
 
 @pytest.mark.parametrize('variant', variants)
@@ -56,14 +56,15 @@ def test_custom_variant_mutation_to_row(variant):
     custom_variant = CustomVariant(variant, 'vcf_alias', 'VARIANT_ID')
 
     # Initialise custom variant mutation
-    cvm = CustomVariantMutation(custom_variant, seq)
+    cvm = CustomVariantMutation(custom_variant, seq, frozenset())
 
     # Check custom variant mutation
-    vcf_alias, vcf_variant_id, var_type_, pos, ref, alt, seq_ = cvm.to_row()
+    vcf_alias, vcf_variant_id, var_type_, pos, ref, alt, seq_, sgrna_ids = cvm.to_row()
     assert vcf_alias == custom_variant.vcf_alias
     assert vcf_variant_id == custom_variant.vcf_variant_id
     assert var_type_ == var_type.value
     assert pos == custom_variant.base_variant.genomic_position.position
+    assert sgrna_ids == ''
 
     if var_type != VariantType.INSERTION:
         assert ref == custom_variant.base_variant.ref
@@ -101,7 +102,7 @@ def test_custom_variant_mutation_collection_from_variants(variant, mseq):
     vcf_var_id = 'VARIANT_ID'
     var_type = variant.type
     custom_variant = CustomVariant(variant, vcf_alias, vcf_var_id)
-    cvm = CustomVariantMutation(custom_variant, mseq)
+    cvm = CustomVariantMutation(custom_variant, mseq, frozenset())
 
     # Initialise mutation collection
     cvmc = CustomVariantMutationCollection.from_variants([cvm])

--- a/tests/unit_tests/test_deletions.py
+++ b/tests/unit_tests/test_deletions.py
@@ -40,12 +40,13 @@ del_offset_method = {
 ])
 @pytest.mark.parametrize('cds', [True, False])
 def test_get_2del_mutations(offset, seq, exp_pos, exp_ref, exp_mseq, cds):
+    cds_suffix = 'A' * (7 - len(seq))
 
     # Generate target
     gr = GenomicRange('X', 10, 10 + len(seq) - 1, '+')
     pam_seq = get_no_op_pam_protected_sequence(seq, gr)
     t = (
-        CDSTargeton.from_pam_seq(pam_seq, 'AA', 'A') if cds else
+        CDSTargeton.from_pam_seq(pam_seq, 'AA', cds_suffix) if cds else
         Targeton.from_pam_seq(pam_seq)
     )
 

--- a/tests/unit_tests/test_deletions.py
+++ b/tests/unit_tests/test_deletions.py
@@ -22,6 +22,7 @@ from valiant.enums import VariantType
 from valiant.models.base import GenomicRange
 from valiant.models.pam_protection import PamProtectedReferenceSequence
 from valiant.models.targeton import Targeton, CDSTargeton
+from .utils import get_no_op_pam_protected_sequence
 
 del_var_type = np.int8(VariantType.DELETION.value)
 
@@ -42,9 +43,10 @@ def test_get_2del_mutations(offset, seq, exp_pos, exp_ref, exp_mseq, cds):
 
     # Generate target
     gr = GenomicRange('X', 10, 10 + len(seq) - 1, '+')
+    pam_seq = get_no_op_pam_protected_sequence(seq, gr)
     t = (
-        CDSTargeton.from_pam_seq(PamProtectedReferenceSequence(seq, gr, seq), 'AA', 'A') if cds else
-        Targeton.from_pam_seq(PamProtectedReferenceSequence(seq, gr, seq))
+        CDSTargeton.from_pam_seq(pam_seq, 'AA', 'A') if cds else
+        Targeton.from_pam_seq(pam_seq)
     )
 
     # Generate in-frame deletions
@@ -69,7 +71,8 @@ def test_get_inframe_mutations(seq, pre, suf, strand, exp_pos, exp_ref, exp_mseq
 
     # Generate target
     gr = GenomicRange('X', 10, 10 + len(seq) - 1, strand)
-    t = CDSTargeton.from_pam_seq(PamProtectedReferenceSequence(seq, gr, seq), pre, suf)
+    pam_seq = get_no_op_pam_protected_sequence(seq, gr)
+    t = CDSTargeton.from_pam_seq(pam_seq, pre, suf)
 
     # Generate in-frame deletions
     mc = t.get_inframe_mutations()

--- a/tests/unit_tests/test_oligo_template.py
+++ b/tests/unit_tests/test_oligo_template.py
@@ -26,7 +26,7 @@ from valiant.models.pam_protection import PamProtectedReferenceSequence
 from valiant.models.sequences import Sequence, ReferenceSequence
 from valiant.models.targeton import Targeton
 from .constants import CODON_TABLE_FP, DUMMY_PAM_PROTECTION_NT
-from .utils import get_data_file_path, get_targeton
+from .utils import get_data_file_path, get_no_op_pam_protected_sequence, get_targeton
 
 TRANSCRIPT_INFO = TranscriptInfo('GENE_ID', 'TRANSCRIPT_ID')
 
@@ -44,10 +44,9 @@ def test_oligo_compute_mutations(targetons, mutator, pam_protection):
 
     ct = CodonTable.load(get_data_file_path(CODON_TABLE_FP))
     ref_seq = ''.join(targetons)
-    pam_ref_seq = PamProtectedReferenceSequence(
-        ref_seq,
-        GenomicRange('X', 1, sum(len(seq) for seq in targetons), '+'),
-        ref_seq)
+
+    gr = GenomicRange('X', 1, sum(len(seq) for seq in targetons), '+')
+    pam_ref_seq = get_no_op_pam_protected_sequence(ref_seq, gr)
 
     adaptor_5 = 'AAAAAA'
     adaptor_3 = 'AAAAAA'

--- a/tests/unit_tests/test_oligo_template.py
+++ b/tests/unit_tests/test_oligo_template.py
@@ -16,7 +16,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #############################
 
-from dataclasses import dataclass
 import pytest
 from valiant.enums import TargetonMutator
 from valiant.models.base import GenomicRange, TranscriptInfo
@@ -55,15 +54,15 @@ def test_oligo_compute_mutations(targetons, mutator, pam_protection):
     ot = OligoTemplate(TRANSCRIPT_INFO, pam_ref_seq, set(), set(), adaptor_5, adaptor_3, segments)
     for _, target_segment in ot.target_segments:
         mutation_collections = target_segment.compute_mutations(ct)
-        mutation_collection = mutation_collections[mutator]
+        df = mutation_collections[mutator].df
         if pam_protection:
             if mutator == TargetonMutator.DEL1:
                 assert all(
-                    set(m.sequence) == {DUMMY_PAM_PROTECTION_NT}
-                    for m in mutation_collection.mutations
+                    set(m.mseq) == {DUMMY_PAM_PROTECTION_NT}
+                    for m in df.itertuples()
                 )
             elif mutator == TargetonMutator.SNV:
                 assert all(
-                    set(m.sequence) - {m.new} == {DUMMY_PAM_PROTECTION_NT}
-                    for m in mutation_collection.mutations
+                    set(m.mseq) - {m.new} == {DUMMY_PAM_PROTECTION_NT}
+                    for m in df.itertuples()
                 )

--- a/tests/unit_tests/test_pam.py
+++ b/tests/unit_tests/test_pam.py
@@ -33,7 +33,7 @@ def test_compute_pam_protected_sequence(seq, pos, ref, alt, ppseq, valid):
     start = 100
     end = start + len(seq) - 1
 
-    variant = PamVariant(GenomicPosition(chromosome, pos), ref, alt)
+    variant = PamVariant(GenomicPosition(chromosome, pos), ref, alt, 'sgrna-1')
 
     gr = GenomicRange(chromosome, start, end, '+')
     ref_seq = ReferenceSequence(seq, gr)

--- a/tests/unit_tests/test_sgrna_ids.py
+++ b/tests/unit_tests/test_sgrna_ids.py
@@ -1,0 +1,98 @@
+########## LICENCE ##########
+# VaLiAnT
+# Copyright (C) 2020, 2021, 2022 Genome Research Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#############################
+
+import pytest
+
+from valiant.models.base import GenomicRange, GenomicPosition
+from valiant.models.sequences import ReferenceSequence
+from valiant.models.oligo_segment import InvariantOligoSegment, TargetonOligoSegment
+from valiant.models.custom_variants import CustomVariant
+from valiant.models.oligo_template import OligoTemplate
+from valiant.models.targeton import PamProtTargeton, PamProtCDSTargeton
+from valiant.models.pam_protection import PamProtectedReferenceSequence, PamVariant
+from valiant.models.variant import DeletionVariant, SubstitutionVariant, InsertionVariant
+
+
+CHR = 'X'
+STRAND = '+'
+SEQ_START = 500
+EXON_REGION_INDEX = 1
+EXON_PAM_OFFSET = 15
+
+
+@pytest.mark.parametrize('variant', [
+    DeletionVariant(GenomicPosition(CHR, SEQ_START + 1), 'A' * 25),
+    SubstitutionVariant(GenomicPosition(CHR, SEQ_START + 1), 'A' * 25, 'C' * 20),
+    InsertionVariant(GenomicPosition(CHR, SEQ_START + EXON_PAM_OFFSET), 'C' * 20)
+])
+@pytest.mark.parametrize('non_cds_region', [True, False])
+def test_oligo_template_get_custom_variant_sgrna_ids(variant, non_cds_region):
+    """
+    Generate three regions, each with one PAM variant.
+    Make all or only the second region exonic, depending on `non_cds_region`.
+    """
+
+    all_sgrna_ids = [f"sgrna-{i}" for i in range(3)]
+    pam_variant_offsets = [5, EXON_PAM_OFFSET, 25]
+    seq_length = 30
+    seq_start = SEQ_START
+    pam_variants = [
+        PamVariant(GenomicPosition(CHR, seq_start + offset), 'A', 'T', sgrna_id)
+        for sgrna_id, offset in zip(all_sgrna_ids, pam_variant_offsets)
+    ]
+    ref_seq = ReferenceSequence(
+        'A' * seq_length, GenomicRange(CHR, seq_start, seq_start + seq_length - 1, STRAND))
+
+    pam_seq = PamProtectedReferenceSequence.from_reference_sequence(
+        ref_seq, pam_variants)
+
+    custom_variant = CustomVariant(variant, None, None)
+
+    # Mark all or just the middle region as exonic
+    def get_targeton(region_index, region):
+        return (
+            PamProtTargeton.from_pam_seq(region)
+            if non_cds_region and region_index != EXON_REGION_INDEX else
+            PamProtCDSTargeton.from_pam_seq(region, 'AA', '')
+        )
+
+    regions = [
+        pam_seq.get_subsequence(GenomicRange(CHR, start, end, STRAND))
+        for start, end in [
+            (seq_start + i * 10, seq_start + (i + 1) * 10 - 1)
+            for i in range(3)
+        ]
+    ]
+
+    segments = [
+        InvariantOligoSegment(get_targeton(i, region))
+        for i, region in enumerate(regions)
+    ]
+
+    ot = OligoTemplate(
+        None, pam_seq, frozenset(all_sgrna_ids), {custom_variant}, None, None, segments)
+
+    # Get sgRNA of the PAM variants in codons that are included in the custom mutation
+    sgrna_ids = ot._get_custom_variant_sgrna_ids(custom_variant)
+
+    sgrna_ids_exp = (
+        frozenset(all_sgrna_ids if not isinstance(variant, InsertionVariant) and not non_cds_region else
+        [all_sgrna_ids[EXON_REGION_INDEX]])
+    )
+
+    assert sgrna_ids == sgrna_ids_exp

--- a/tests/unit_tests/test_sgrna_ids.py
+++ b/tests/unit_tests/test_sgrna_ids.py
@@ -90,9 +90,9 @@ def test_oligo_template_get_custom_variant_sgrna_ids(variant, non_cds_region):
     # Get sgRNA of the PAM variants in codons that are included in the custom mutation
     sgrna_ids = ot._get_custom_variant_sgrna_ids(custom_variant)
 
-    sgrna_ids_exp = (
-        frozenset(all_sgrna_ids if not isinstance(variant, InsertionVariant) and not non_cds_region else
-        [all_sgrna_ids[EXON_REGION_INDEX]])
+    sgrna_ids_exp = frozenset(
+        all_sgrna_ids if not isinstance(variant, InsertionVariant) and not non_cds_region else
+        [all_sgrna_ids[EXON_REGION_INDEX]]
     )
 
     assert sgrna_ids == sgrna_ids_exp

--- a/tests/unit_tests/test_targeton.py
+++ b/tests/unit_tests/test_targeton.py
@@ -1,0 +1,56 @@
+########## LICENCE ##########
+# VaLiAnT
+# Copyright (C) 2020, 2021, 2022 Genome Research Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#############################
+
+import pytest
+from valiant.enums import MutationType
+from valiant.models.base import GenomicPosition, GenomicRange
+from valiant.models.pam_protection import PamProtectedReferenceSequence, PamVariant
+from valiant.models.sequences import ReferenceSequence
+from valiant.models.targeton import PamProtCDSTargeton
+from .utils import load_codon_table
+
+
+codon_table = load_codon_table()
+
+
+def test_pam_prot_targeton_from_reference_sequence():
+    chromosome = 'X'
+    ref_seq = ReferenceSequence('ACGTCA', GenomicRange(chromosome, 500, 505, '+'))
+    pam_variant = PamVariant(GenomicPosition(chromosome, 501), 'C', 'G')
+    pam_seq = PamProtectedReferenceSequence.from_reference_sequence(ref_seq, [pam_variant])
+    PamProtCDSTargeton.from_pam_seq(pam_seq, 'AT', 'C')
+
+
+@pytest.mark.parametrize('alt,mut_type', [
+    ('T', MutationType.SYNONYMOUS),
+    ('G', MutationType.MISSENSE),
+    ('A', MutationType.NONSENSE)
+])
+def test_pam_prot_targeton_get_pam_variant_annotations(alt, mut_type):
+    # Codon table
+    # TGA -> STOP
+    # TGC -> C
+    # TGT -> C
+    # TGG -> W
+
+    chromosome = 'X'
+    ref_seq = ReferenceSequence('GCGTGC', GenomicRange(chromosome, 500, 505, '+'))
+    pam_variant = PamVariant(GenomicPosition(chromosome, 501), 'C', alt)
+    pam_seq = PamProtectedReferenceSequence.from_reference_sequence(ref_seq, [pam_variant])
+    targeton = PamProtCDSTargeton.from_pam_seq(pam_seq, 'T', 'CA')
+    assert targeton.get_pam_variant_annotations(codon_table) == [mut_type]

--- a/tests/unit_tests/test_targeton.py
+++ b/tests/unit_tests/test_targeton.py
@@ -19,6 +19,7 @@
 from contextlib import nullcontext
 import pandas as pd
 import pytest
+from valiant.constants import META_PAM_MUT_SGRNA_ID, META_MUT_POSITION
 from valiant.enums import MutationType, TargetonMutator
 from valiant.models.annotated_sequence import CDSAnnotatedSequencePair
 from valiant.models.base import GenomicPosition, GenomicRange
@@ -100,14 +101,13 @@ def test_pam_prot_targeton_compute_mutations(pam_variant_clash):
 
         assert len(mutation_collections) == 1
 
-        # Verify the temporay field was dropped
+        # Verify the temporary field was dropped
 
         df = mutation_collections[mutator].df
-        assert '_codon_index' not in df.columns
 
         # Validate the sgRNA ID field
-        df['codon_index'] = (df['mut_position'] + frame) // 3
+        df['codon_index'] = (df[META_MUT_POSITION] + frame) // 3
         mask = df['codon_index'].mod(2).ne(0)
-        assert pd.isna(df.loc[mask, 'meta_pam_mut_sgrna_id'].unique())
-        assert df.loc[df.codon_index == 0, 'meta_pam_mut_sgrna_id'].unique() == sgrna_id_1
-        assert df.loc[df.codon_index == 2, 'meta_pam_mut_sgrna_id'].unique() == sgrna_id_2
+        assert df.loc[mask, META_PAM_MUT_SGRNA_ID].unique() == ''
+        assert df.loc[df.codon_index == 0, META_PAM_MUT_SGRNA_ID].unique() == sgrna_id_1
+        assert df.loc[df.codon_index == 2, META_PAM_MUT_SGRNA_ID].unique() == sgrna_id_2

--- a/tests/unit_tests/test_targeton.py
+++ b/tests/unit_tests/test_targeton.py
@@ -16,21 +16,27 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #############################
 
+from contextlib import nullcontext
+import pandas as pd
 import pytest
-from valiant.enums import MutationType
+from valiant.enums import MutationType, TargetonMutator
 from valiant.models.annotated_sequence import CDSAnnotatedSequencePair
 from valiant.models.base import GenomicPosition, GenomicRange
 from valiant.models.pam_protection import PamVariant
 from valiant.models.targeton import PamProtCDSTargeton
-from .utils import load_codon_table
+from .utils import get_aux_tables
+
+
+aux = get_aux_tables()
+codon_table = aux.codon_table
 
 
 SGRNA_ID = 'some-id'
-codon_table = load_codon_table()
+TEST_CHROMOSOME = 'X'
 
 
 def test_pam_prot_targeton_from_reference_sequence():
-    chromosome = 'X'
+    chromosome = TEST_CHROMOSOME
     PamProtCDSTargeton(CDSAnnotatedSequencePair(
         GenomicRange(chromosome, 500, 505, '+'),
         'ACGTCA',
@@ -52,7 +58,7 @@ def test_pam_prot_targeton_get_pam_variant_annotations(alt, mut_type):
     # TGT -> C
     # TGG -> W
 
-    chromosome = 'X'
+    chromosome = TEST_CHROMOSOME
     PamProtCDSTargeton(CDSAnnotatedSequencePair(
         GenomicRange(chromosome, 500, 505, '+'),
         'GCGTGC',
@@ -60,3 +66,48 @@ def test_pam_prot_targeton_get_pam_variant_annotations(alt, mut_type):
         [PamVariant(GenomicPosition(chromosome, 501), 'C', alt, SGRNA_ID)],
         'T',
         'CA'))
+
+
+@pytest.mark.parametrize('pam_variant_clash', [True, False])
+def test_pam_prot_targeton_compute_mutations(pam_variant_clash):
+    chromosome = TEST_CHROMOSOME
+    ref_seq = 'ACGTCAGCG'
+    genomic_range =  GenomicRange(chromosome, 500, 500 + len(ref_seq) - 1, '+')
+    mutator = TargetonMutator.SNV
+    pam_variant_pos = 501 if pam_variant_clash else 507
+    sgrna_id_1 = 'sgrna-a'
+    sgrna_id_2 = 'sgrna-b'
+    variants = [
+        PamVariant(GenomicPosition(chromosome, 500), 'A', 'G', sgrna_id_1),
+        PamVariant(GenomicPosition(chromosome, pam_variant_pos), 'C', 'G', sgrna_id_2)
+    ]
+    pam_seq = variants[0].mutate(ref_seq, genomic_range.start, ref_check=True)
+    pam_seq = variants[1].mutate(pam_seq, genomic_range.start, ref_check=True)
+    cds_prefix = 'A'
+    frame = len(cds_prefix)
+
+    # Generate targeton
+    with pytest.raises(ValueError) if pam_variant_clash else nullcontext():
+        targeton: PamProtCDSTargeton = PamProtCDSTargeton(
+            CDSAnnotatedSequencePair(
+                genomic_range, ref_seq, pam_seq, variants, cds_prefix, 'CG'))
+
+    if not pam_variant_clash:
+
+        # Generate mutations
+        mutation_collections = targeton.compute_mutations(
+            frozenset([mutator]), aux, sgrna_ids=frozenset([sgrna_id_1, sgrna_id_2]))
+
+        assert len(mutation_collections) == 1
+
+        # Verify the temporay field was dropped
+
+        df = mutation_collections[mutator].df
+        assert '_codon_index' not in df.columns
+
+        # Validate the sgRNA ID field
+        df['codon_index'] = (df['mut_position'] + frame) // 3
+        mask = df['codon_index'].mod(2).ne(0)
+        assert pd.isna(df.loc[mask, 'meta_pam_mut_sgrna_id'].unique())
+        assert df.loc[df.codon_index == 0, 'meta_pam_mut_sgrna_id'].unique() == sgrna_id_1
+        assert df.loc[df.codon_index == 2, 'meta_pam_mut_sgrna_id'].unique() == sgrna_id_2

--- a/tests/unit_tests/test_targeton.py
+++ b/tests/unit_tests/test_targeton.py
@@ -18,9 +18,9 @@
 
 import pytest
 from valiant.enums import MutationType
+from valiant.models.annotated_sequence import CDSAnnotatedSequencePair
 from valiant.models.base import GenomicPosition, GenomicRange
-from valiant.models.pam_protection import PamProtectedReferenceSequence, PamVariant
-from valiant.models.sequences import ReferenceSequence
+from valiant.models.pam_protection import PamVariant
 from valiant.models.targeton import PamProtCDSTargeton
 from .utils import load_codon_table
 
@@ -31,13 +31,13 @@ codon_table = load_codon_table()
 
 def test_pam_prot_targeton_from_reference_sequence():
     chromosome = 'X'
-    PamProtCDSTargeton(
+    PamProtCDSTargeton(CDSAnnotatedSequencePair(
         GenomicRange(chromosome, 500, 505, '+'),
         'ACGTCA',
         'AGGTCA',
         [PamVariant(GenomicPosition(chromosome, 501), 'C', 'G', SGRNA_ID)],
         'AT',
-        'C')
+        'C'))
 
 
 @pytest.mark.parametrize('alt,mut_type', [
@@ -53,10 +53,10 @@ def test_pam_prot_targeton_get_pam_variant_annotations(alt, mut_type):
     # TGG -> W
 
     chromosome = 'X'
-    PamProtCDSTargeton(
+    PamProtCDSTargeton(CDSAnnotatedSequencePair(
         GenomicRange(chromosome, 500, 505, '+'),
         'GCGTGC',
         f"G{alt}GTGC",
         [PamVariant(GenomicPosition(chromosome, 501), 'C', alt, SGRNA_ID)],
         'T',
-        'CA')
+        'CA'))

--- a/tests/unit_tests/test_targeton.py
+++ b/tests/unit_tests/test_targeton.py
@@ -73,7 +73,7 @@ def test_pam_prot_targeton_get_pam_variant_annotations(alt, mut_type):
 def test_pam_prot_targeton_compute_mutations(pam_variant_clash):
     chromosome = TEST_CHROMOSOME
     ref_seq = 'ACGTCAGCG'
-    genomic_range =  GenomicRange(chromosome, 500, 500 + len(ref_seq) - 1, '+')
+    genomic_range = GenomicRange(chromosome, 500, 500 + len(ref_seq) - 1, '+')
     mutator = TargetonMutator.SNV
     pam_variant_pos = 501 if pam_variant_clash else 507
     sgrna_id_1 = 'sgrna-a'

--- a/tests/unit_tests/test_targeton.py
+++ b/tests/unit_tests/test_targeton.py
@@ -25,15 +25,19 @@ from valiant.models.targeton import PamProtCDSTargeton
 from .utils import load_codon_table
 
 
+SGRNA_ID = 'some-id'
 codon_table = load_codon_table()
 
 
 def test_pam_prot_targeton_from_reference_sequence():
     chromosome = 'X'
-    ref_seq = ReferenceSequence('ACGTCA', GenomicRange(chromosome, 500, 505, '+'))
-    pam_variant = PamVariant(GenomicPosition(chromosome, 501), 'C', 'G')
-    pam_seq = PamProtectedReferenceSequence.from_reference_sequence(ref_seq, [pam_variant])
-    PamProtCDSTargeton.from_pam_seq(pam_seq, 'AT', 'C')
+    PamProtCDSTargeton(
+        GenomicRange(chromosome, 500, 505, '+'),
+        'ACGTCA',
+        'AGGTCA',
+        [PamVariant(GenomicPosition(chromosome, 501), 'C', 'G', SGRNA_ID)],
+        'AT',
+        'C')
 
 
 @pytest.mark.parametrize('alt,mut_type', [
@@ -49,8 +53,10 @@ def test_pam_prot_targeton_get_pam_variant_annotations(alt, mut_type):
     # TGG -> W
 
     chromosome = 'X'
-    ref_seq = ReferenceSequence('GCGTGC', GenomicRange(chromosome, 500, 505, '+'))
-    pam_variant = PamVariant(GenomicPosition(chromosome, 501), 'C', alt)
-    pam_seq = PamProtectedReferenceSequence.from_reference_sequence(ref_seq, [pam_variant])
-    targeton = PamProtCDSTargeton.from_pam_seq(pam_seq, 'T', 'CA')
-    assert targeton.get_pam_variant_annotations(codon_table) == [mut_type]
+    PamProtCDSTargeton(
+        GenomicRange(chromosome, 500, 505, '+'),
+        'GCGTGC',
+        f"G{alt}GTGC",
+        [PamVariant(GenomicPosition(chromosome, 501), 'C', alt, SGRNA_ID)],
+        'T',
+        'CA')

--- a/tests/unit_tests/utils.py
+++ b/tests/unit_tests/utils.py
@@ -43,11 +43,16 @@ def get_dummy_pam_protected(seq):
     return DUMMY_PAM_PROTECTION_NT * len(seq)
 
 
+def get_no_op_pam_protected_sequence(seq, genomic_range):
+    return PamProtectedReferenceSequence.from_reference_sequence(
+        ReferenceSequence(seq, genomic_range), [])
+
+
+# TODO: make it valid (no same-codon PAM protection)?
 def get_pam_protected_sequence(seq, pam_protection, chromosome='X', strand='+', pos=1):
     gr = GenomicRange(chromosome, pos, len(seq), strand)
-    ref_seq = ReferenceSequence(seq, gr)
-    return PamProtectedReferenceSequence.from_reference_sequence(
-        ref_seq, get_dummy_pam_protected(seq) if pam_protection else seq)
+    pam_seq = get_dummy_pam_protected(seq) if pam_protection else seq
+    return PamProtectedReferenceSequence(seq, gr, pam_seq, [])
 
 
 def get_targeton(seq, pam_protection, chromosome='X', strand='+', pos=1):


### PR DESCRIPTION
New:

- report the types of mutations of each PAM protection variant applied to a targeton (new metadata table field `pam_mut_annot`)
- when mutations that span exonic regions can be affected by PAM protection variants, report the corresponding sgRNA identifiers (new metadata table field `pam_mut_sgrna_id`)

Changed:

- upgrade dependencies
- refactor targeton models